### PR TITLE
Infer int timestamps

### DIFF
--- a/src/@types.ts
+++ b/src/@types.ts
@@ -1,4 +1,4 @@
-import { JSONStringFormat, JSONObjectFormat } from "./formats";
+import { JSONStringFormat, JSONObjectFormat, JSONIntFormat } from "./formats";
 
 export type JSONNullType = {
   name: "null";
@@ -17,6 +17,7 @@ export type JSONFloatType = {
 
 export type JSONIntType = {
   name: "int";
+  format?: JSONIntFormat;
   value: number;
 };
 

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -119,3 +119,19 @@ export function inferObjectFormat(value: object): JSONObjectFormat | undefined {
 
   return undefined;
 }
+
+export type JSONIntFormat = JSONTimestampFormat
+
+const intFormats = [inferTimestamp];
+
+export function inferIntFormat(value: number): JSONIntFormat | undefined {
+  for (const [, format] of Object.entries(intFormats)) {
+    const result = format(value);
+
+    if (result) {
+      return result;
+    }
+  }
+
+  return undefined;
+}

--- a/src/formats/timestamp.ts
+++ b/src/formats/timestamp.ts
@@ -3,7 +3,7 @@ export type JSONTimestampFormat = {
   variant: "millisecondsSinceEpoch" | "nanosecondsSinceEpoch" | "secondsSinceEpoch";
 };
 
-const timestampSecondsSinceEpoch = /^\d{10}$/;
+const timestampSecondsSinceEpoch = /^\d{10}$/; 1664976736
 const timestampMsSinceEpoch = /^\d{13}$/;
 const timestampNanoSinceEpoch = /^\d{19}$/;
 
@@ -18,7 +18,10 @@ function inRangeOfNow(msSinceEpoch: number): boolean {
   return now >= lowerBound && now <= upperBound;
 }
 
-export function inferTimestamp(value: string): JSONTimestampFormat | undefined {
+export function inferTimestamp(value: string | number): JSONTimestampFormat | undefined {
+  if (typeof value === "number") {
+    value = "" + value
+  }
   if (timestampSecondsSinceEpoch.test(value)) {
     const seconds = parseInt(value);
 

--- a/src/formats/timestamp.ts
+++ b/src/formats/timestamp.ts
@@ -20,7 +20,7 @@ function inRangeOfNow(msSinceEpoch: number): boolean {
 
 export function inferTimestamp(value: string | number): JSONTimestampFormat | undefined {
   if (typeof value === "number") {
-    value = "" + value
+    return inferTimestamp(`${value}`);
   }
   if (timestampSecondsSinceEpoch.test(value)) {
     const seconds = parseInt(value);

--- a/src/formats/timestamp.ts
+++ b/src/formats/timestamp.ts
@@ -3,7 +3,7 @@ export type JSONTimestampFormat = {
   variant: "millisecondsSinceEpoch" | "nanosecondsSinceEpoch" | "secondsSinceEpoch";
 };
 
-const timestampSecondsSinceEpoch = /^\d{10}$/; 1664976736
+const timestampSecondsSinceEpoch = /^\d{10}$/;
 const timestampMsSinceEpoch = /^\d{13}$/;
 const timestampNanoSinceEpoch = /^\d{19}$/;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { JSONValueType } from "./@types";
-import { inferFormat, inferObjectFormat } from "./formats";
+import { inferFormat, inferObjectFormat, inferIntFormat } from "./formats";
 
 export { JSONValueType };
 export {
@@ -45,7 +45,11 @@ export function inferType(value: unknown): JSONValueType {
 
   if (typeof value === "number") {
     if (Number.isInteger(value)) {
-      return { name: "int", value };
+      return { 
+        name: "int", 
+        value,
+        format: inferIntFormat(value),
+      };
     } else {
       return { name: "float", value };
     }

--- a/tests/intFormats.test.ts
+++ b/tests/intFormats.test.ts
@@ -1,0 +1,51 @@
+import { inferType } from "../src";
+
+describe("timestamps", () => {
+  test.each([1664976736123, 1664976736567])(
+    "%p should be inferred as an timestamp",
+    (value) => {
+      expect(inferType(value)).toEqual({
+        name: "int",
+        value,
+        format: {
+          name: "timestamp",
+          variant: "millisecondsSinceEpoch",
+        },
+      });
+    },
+  );
+
+  test.each([1664976736, 1664976736])("%p should be inferred as an timestamp", (value) => {
+    expect(inferType(value)).toEqual({
+      name: "int",
+      value,
+      format: {
+        name: "timestamp",
+        variant: "secondsSinceEpoch",
+      },
+    });
+  });
+
+  test.each([1664976736946364285])("%p should be inferred as an timestamp", (value) => {
+    expect(inferType(value)).toEqual({
+      name: "int",
+      value,
+      format: {
+        name: "timestamp",
+        variant: "nanosecondsSinceEpoch",
+      },
+    });
+  });
+});
+
+describe("without format", () => {
+  test.each([46, 2244994945, 1212092628029698048])(
+    "%p should be inferred as having no format",
+    (value) => {
+      expect(inferType(value)).toEqual({
+        name: "int",
+        value,
+      });
+    },
+  );
+});

--- a/tests/stringFormats.test.ts
+++ b/tests/stringFormats.test.ts
@@ -162,7 +162,7 @@ describe("rfc2822", () => {
 });
 
 describe("timestamps", () => {
-  test.each(["1596597629980", "1640273437757"])(
+  test.each(["1664976736980", "1640273437757"])(
     "%p should be inferred as an timestamp",
     (value) => {
       expect(inferType(value)).toEqual({
@@ -187,7 +187,7 @@ describe("timestamps", () => {
     });
   });
 
-  test.each(["1596597839946364285"])("%p should be inferred as an timestamp", (value) => {
+  test.each(["1664976736946364285"])("%p should be inferred as an timestamp", (value) => {
     expect(inferType(value)).toEqual({
       name: "string",
       value,


### PR DESCRIPTION
Based on discussion at https://github.com/apihero-run/jsonhero-web/issues/87

This PR adds functionality to infer a timestamp from an Int.

Happy to take feedback and make changes as necessary